### PR TITLE
feat(datastore) Allow configure DataStore with custom configuration

### DIFF
--- a/packages/amplify_analytics_pinpoint/android/build.gradle
+++ b/packages/amplify_analytics_pinpoint/android/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.17.4'
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.4'
+    implementation 'com.amplifyframework:aws-analytics-pinpoint:1.17.6'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.17.6'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_api/android/build.gradle
+++ b/packages/amplify_api/android/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     api amplifyCore
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-api:1.17.4"
-    implementation "com.amplifyframework:aws-api-appsync:1.17.4"
+    implementation "com.amplifyframework:aws-api:1.17.6"
+    implementation "com.amplifyframework:aws-api-appsync:1.17.6"
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_auth_cognito/android/build.gradle
+++ b/packages/amplify_auth_cognito/android/build.gradle
@@ -61,7 +61,7 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-auth-cognito:1.17.4'
+    implementation 'com.amplifyframework:aws-auth-cognito:1.17.6'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_core/android/build.gradle
+++ b/packages/amplify_core/android/build.gradle
@@ -61,7 +61,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:core:1.17.4'
+    implementation 'com.amplifyframework:core:1.17.6'
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_datastore/android/build.gradle
+++ b/packages/amplify_datastore/android/build.gradle
@@ -57,8 +57,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplifyframework:aws-datastore:1.17.4"
-    implementation "com.amplifyframework:aws-api-appsync:1.17.4"
+    implementation "com.amplifyframework:aws-datastore:1.17.6"
+    implementation "com.amplifyframework:aws-api-appsync:1.17.6"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.mockito:mockito-inline:3.1.0'

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -147,17 +147,14 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
 
         val defaultDataStoreConfiguration = DataStoreConfiguration.defaults();
         val syncInterval: Long =
-            if (request["syncInterval"] is Int)
-                TimeUnit.SECONDS.toMinutes((request["syncInterval"] as Int).toLong())
-            else defaultDataStoreConfiguration.syncIntervalInMinutes;
+            (request["syncInterval"] as? Int)?.toLong()
+                ?: defaultDataStoreConfiguration.syncIntervalInMinutes;
         val syncMaxRecords: Int =
-            if (request["syncMaxRecords"] is Int)
-                request["syncMaxRecords"] as Int
-            else defaultDataStoreConfiguration.syncMaxRecords;
+            (request["syncMaxRecords"] as? Int)
+                ?: defaultDataStoreConfiguration.syncMaxRecords;
         val syncPageSize: Int =
-            if(request["syncPageSize"] is Int)
-                request["syncPageSize"] as Int
-            else defaultDataStoreConfiguration.syncPageSize;
+            (request["syncPageSize"] as? Int)
+                ?: defaultDataStoreConfiguration.syncPageSize;
 
         try {
             Amplify.addPlugin(

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -38,6 +38,7 @@ import com.amplifyframework.core.model.Model
 import com.amplifyframework.core.model.query.QueryOptions
 import com.amplifyframework.core.model.query.predicate.QueryPredicates
 import com.amplifyframework.datastore.AWSDataStorePlugin
+import com.amplifyframework.datastore.DataStoreConfiguration
 import com.amplifyframework.datastore.DataStoreException
 import com.amplifyframework.datastore.appsync.SerializedModel
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -46,6 +47,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import java.util.concurrent.TimeUnit
 
 /** AmplifyDataStorePlugin */
 class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
@@ -143,11 +145,38 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
 
         modelProvider.setVersion(request["modelProviderVersion"] as String)
 
+        val defaultDataStoreConfiguration = DataStoreConfiguration.defaults();
+        val syncInterval: Long =
+            if (request["syncInterval"] is Int)
+                TimeUnit.SECONDS.toMinutes((request["syncInterval"] as Int).toLong())
+            else defaultDataStoreConfiguration.syncIntervalInMinutes;
+        val syncMaxRecords: Int =
+            if (request["syncMaxRecords"] is Int)
+                request["syncMaxRecords"] as Int
+            else defaultDataStoreConfiguration.syncMaxRecords;
+        val syncPageSize: Int =
+            if(request["syncPageSize"] is Int)
+                request["syncPageSize"] as Int
+            else defaultDataStoreConfiguration.syncPageSize;
+
         try {
-            Amplify.addPlugin(AWSDataStorePlugin(modelProvider))
+            Amplify.addPlugin(
+                AWSDataStorePlugin
+                    .builder()
+                    .modelProvider(modelProvider)
+                    .dataStoreConfiguration(
+                        DataStoreConfiguration
+                            .builder()
+                            .syncInterval(syncInterval, TimeUnit.MINUTES)
+                            .syncMaxRecords(syncMaxRecords)
+                            .syncPageSize(syncPageSize)
+                            .build()
+                    )
+                    .build()
+            )
         } catch (e: Exception) {
             handleAddPluginException("Datastore", e, flutterResult)
-            return 
+            return
         }
         flutterResult.success(null)
     }

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -85,9 +85,9 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             return //TODO
         }
 
-        let syncInterval = args["syncInterval"] as? Double;
-        let syncMaxRecords = args["syncMaxRecords"] as? UInt
-        let syncPageSize = args["syncPageSize"] as? UInt;
+        let syncInterval = args["syncInterval"] as? Double ?? DataStoreConfiguration.defaultSyncInterval
+        let syncMaxRecords = args["syncMaxRecords"] as? UInt ?? DataStoreConfiguration.defaultSyncMaxRecords
+        let syncPageSize = args["syncPageSize"] as? UInt ?? DataStoreConfiguration.defaultSyncPageSize
 
         do {
 
@@ -103,9 +103,9 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
 
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: flutterModelRegistration,
                 configuration: .custom(
-                    syncInterval: syncInterval ?? DataStoreConfiguration.defaultSyncInterval,
-                    syncMaxRecords: syncMaxRecords ?? DataStoreConfiguration.defaultSyncMaxRecords,
-                    syncPageSize: syncPageSize ?? DataStoreConfiguration.defaultSyncPageSize))
+                    syncInterval: syncInterval,
+                    syncMaxRecords: syncMaxRecords,
+                    syncPageSize: syncPageSize))
             try Amplify.add(plugin: dataStorePlugin)
             Amplify.Logging.logLevel = .info
             print("Amplify configured with DataStore plugin")

--- a/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
+++ b/packages/amplify_datastore/ios/Classes/SwiftAmplifyDataStorePlugin.swift
@@ -85,6 +85,10 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
             return //TODO
         }
 
+        let syncInterval = args["syncInterval"] as? Double;
+        let syncMaxRecords = args["syncMaxRecords"] as? UInt
+        let syncPageSize = args["syncPageSize"] as? UInt;
+
         do {
 
             let modelSchemas: [ModelSchema] = try modelSchemaList.map {
@@ -97,7 +101,11 @@ public class SwiftAmplifyDataStorePlugin: NSObject, FlutterPlugin {
 
             self.dataStoreHubEventStreamHandler?.registerModelsForHub(flutterModels: flutterModelRegistration)
 
-            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: flutterModelRegistration)
+            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: flutterModelRegistration,
+                configuration: .custom(
+                    syncInterval: syncInterval ?? DataStoreConfiguration.defaultSyncInterval,
+                    syncMaxRecords: syncMaxRecords ?? DataStoreConfiguration.defaultSyncMaxRecords,
+                    syncPageSize: syncPageSize ?? DataStoreConfiguration.defaultSyncPageSize))
             try Amplify.add(plugin: dataStorePlugin)
             Amplify.Logging.logLevel = .info
             print("Amplify configured with DataStore plugin")

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -27,9 +27,25 @@ export 'package:amplify_datastore_plugin_interface/src/publicTypes.dart';
 class AmplifyDataStore extends DataStorePluginInterface {
   static final Object _token = Object();
 
-  /// Constructs an AmplifyDataStore plugin
-  AmplifyDataStore({@required ModelProviderInterface modelProvider})
-      : super(token: _token, modelProvider: modelProvider);
+  /// Constructs an AmplifyDataStore plugin with mandatory [modelProvider]
+  /// and optional datastore configuration properties including
+  ///
+  /// [syncInterval]: datastore syncing interval (in melliseconds)
+  ///
+  /// [syncMaxRecords]: max number of records to sync
+  ///
+  /// [syncPageSize]: page size to sync
+  AmplifyDataStore(
+      {@required ModelProviderInterface modelProvider,
+      double syncInterval,
+      int syncMaxRecords,
+      int syncPageSize})
+      : super(
+            token: _token,
+            modelProvider: modelProvider,
+            syncInterval: syncInterval,
+            syncMaxRecords: syncMaxRecords,
+            syncPageSize: syncPageSize);
 
   static AmplifyDataStore _instance = AmplifyDataStoreMethodChannel();
   static DataStoreStreamController streamWrapper = DataStoreStreamController();
@@ -46,7 +62,10 @@ class AmplifyDataStore extends DataStorePluginInterface {
 
   @override
   Future<void> configureDataStore(
-      {ModelProviderInterface modelProvider}) async {
+      {ModelProviderInterface modelProvider,
+      double syncInterval,
+      int syncMaxRecords,
+      int syncPageSize}) async {
     ModelProviderInterface provider =
         modelProvider == null ? this.modelProvider : modelProvider;
     if (provider == null || provider.modelSchemas.isEmpty) {
@@ -55,7 +74,11 @@ class AmplifyDataStore extends DataStorePluginInterface {
               'Pass in a modelProvider instance while instantiating DataStorePlugin');
     }
     streamWrapper.registerModelsForHub(provider);
-    return _instance.configureDataStore(modelProvider: modelProvider);
+    return _instance.configureDataStore(
+        modelProvider: modelProvider,
+        syncInterval: this.syncInterval,
+        syncMaxRecords: this.syncMaxRecords,
+        syncPageSize: this.syncPageSize);
   }
 
   @override

--- a/packages/amplify_datastore/lib/amplify_datastore.dart
+++ b/packages/amplify_datastore/lib/amplify_datastore.dart
@@ -30,14 +30,14 @@ class AmplifyDataStore extends DataStorePluginInterface {
   /// Constructs an AmplifyDataStore plugin with mandatory [modelProvider]
   /// and optional datastore configuration properties including
   ///
-  /// [syncInterval]: datastore syncing interval (in melliseconds)
+  /// [syncInterval]: datastore syncing interval (in seconds)
   ///
   /// [syncMaxRecords]: max number of records to sync
   ///
   /// [syncPageSize]: page size to sync
   AmplifyDataStore(
       {@required ModelProviderInterface modelProvider,
-      double syncInterval,
+      int syncInterval,
       int syncMaxRecords,
       int syncPageSize})
       : super(
@@ -63,7 +63,7 @@ class AmplifyDataStore extends DataStorePluginInterface {
   @override
   Future<void> configureDataStore(
       {ModelProviderInterface modelProvider,
-      double syncInterval,
+      int syncInterval,
       int syncMaxRecords,
       int syncPageSize}) async {
     ModelProviderInterface provider =

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -31,7 +31,7 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   @override
   Future<void> configureDataStore(
       {ModelProviderInterface modelProvider,
-      double syncInterval,
+      int syncInterval,
       int syncMaxRecords,
       int syncPageSize}) async {
     try {

--- a/packages/amplify_datastore/lib/method_channel_datastore.dart
+++ b/packages/amplify_datastore/lib/method_channel_datastore.dart
@@ -30,13 +30,19 @@ class AmplifyDataStoreMethodChannel extends AmplifyDataStore {
   /// called.
   @override
   Future<void> configureDataStore(
-      {ModelProviderInterface modelProvider}) async {
+      {ModelProviderInterface modelProvider,
+      double syncInterval,
+      int syncMaxRecords,
+      int syncPageSize}) async {
     try {
       return await _channel
           .invokeMethod('configureDataStore', <String, dynamic>{
         'modelSchemas':
             modelProvider.modelSchemas.map((schema) => schema.toMap()).toList(),
-        'modelProviderVersion': modelProvider.version
+        'modelProviderVersion': modelProvider.version,
+        'syncInterval': syncInterval,
+        'syncMaxRecords': syncMaxRecords,
+        'syncPageSize': syncPageSize
       });
     } on PlatformException catch (e) {
       if (e.code == "AmplifyAlreadyConfiguredException") {

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -79,7 +79,7 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
       int syncMaxRecords,
       int syncPageSize}) {
     throw UnimplementedError(
-        'configureModelProvider() has not been implemented.');
+        'configureDataStore() has not been implemented.');
   }
 
   Future<void> setUpObserve() {

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -44,16 +44,42 @@ export 'src/types/models/subscription_event.dart';
 export 'src/publicTypes.dart';
 
 abstract class DataStorePluginInterface extends AmplifyPluginInterface {
+  /// modelProvider
   final ModelProviderInterface modelProvider;
+
+  /// Datastore sync interval (in melliseconds)
+  final double syncInterval;
+
+  /// Datastore max number of records to sync
+  final int syncMaxRecords;
+
+  /// Datastore page size to sync
+  final int syncPageSize;
 
   /// Constructs an AmplifyPlatform.
   DataStorePluginInterface(
-      {@required Object token, @required this.modelProvider})
+      {@required Object token,
+      @required this.modelProvider,
+      this.syncInterval,
+      this.syncMaxRecords,
+      this.syncPageSize})
       : super(token: token);
 
+  /// Configure AmplifyDataStore plugin with mandatory [modelProvider]
+  /// and optional datastore configuration properties including
+  ///
+  /// [syncInterval]: datastore syncing interval (in melliseconds)
+  ///
+  /// [syncMaxRecords]: max number of records to sync
+  ///
+  /// [syncPageSize]: page size to sync
   Future<void> configureDataStore(
-      {@required ModelProviderInterface modelProvider}) {
-    throw UnimplementedError('configureDataStore() has not been implemented.');
+      {@required ModelProviderInterface modelProvider,
+      double syncInterval,
+      int syncMaxRecords,
+      int syncPageSize}) {
+    throw UnimplementedError(
+        'configureModelProvider() has not been implemented.');
   }
 
   Future<void> setUpObserve() {

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -47,8 +47,8 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// modelProvider
   final ModelProviderInterface modelProvider;
 
-  /// Datastore sync interval (in milliseconds)
-  final double syncInterval;
+  /// Datastore sync interval (in seconds)
+  final int syncInterval;
 
   /// Datastore max number of records to sync
   final int syncMaxRecords;
@@ -68,18 +68,17 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// Configure AmplifyDataStore plugin with mandatory [modelProvider]
   /// and optional datastore configuration properties including
   ///
-  /// [syncInterval]: datastore syncing interval (in melliseconds)
+  /// [syncInterval]: datastore syncing interval (in seconds)
   ///
   /// [syncMaxRecords]: max number of records to sync
   ///
   /// [syncPageSize]: page size to sync
   Future<void> configureDataStore(
       {@required ModelProviderInterface modelProvider,
-      double syncInterval,
+      int syncInterval,
       int syncMaxRecords,
       int syncPageSize}) {
-    throw UnimplementedError(
-        'configureDataStore() has not been implemented.');
+    throw UnimplementedError('configureDataStore() has not been implemented.');
   }
 
   Future<void> setUpObserve() {

--- a/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
+++ b/packages/amplify_datastore_plugin_interface/lib/amplify_datastore_plugin_interface.dart
@@ -47,7 +47,7 @@ abstract class DataStorePluginInterface extends AmplifyPluginInterface {
   /// modelProvider
   final ModelProviderInterface modelProvider;
 
-  /// Datastore sync interval (in melliseconds)
+  /// Datastore sync interval (in milliseconds)
   final double syncInterval;
 
   /// Datastore max number of records to sync

--- a/packages/amplify_flutter/android/build.gradle
+++ b/packages/amplify_flutter/android/build.gradle
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     api amplifyCore
-    implementation 'com.amplifyframework:core:1.17.4'
+    implementation 'com.amplifyframework:core:1.17.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.1.0'

--- a/packages/amplify_storage_s3/android/build.gradle
+++ b/packages/amplify_storage_s3/android/build.gradle
@@ -49,5 +49,5 @@ android {
 dependencies {
     api amplifyCore
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.amplifyframework:aws-storage-s3:1.17.4'
+    implementation 'com.amplifyframework:aws-storage-s3:1.17.6'
 }


### PR DESCRIPTION
Changes include iOS support only.
Waiting on `amplify-android` to release this [commit](https://github.com/aws-amplify/amplify-android/commit/0ae1319333bd1a9e7b6d0c722a255427f318573f#diff-1d6639ae83d38f3234fb312bbae544f6b9d92a34a84ce6d046920e29c7d73cd1) to add custom configuration in android

Custom configuration include
* `syncInterval`
* `syncMaxRecords`
* `syncPageSize`